### PR TITLE
Handle optional action property

### DIFF
--- a/triggers/github-trigger-event-sink/handler.py
+++ b/triggers/github-trigger-event-sink/handler.py
@@ -22,15 +22,20 @@ async def handler():
     logging.info("Received event from GitHub: {}".format(github_event))
 
     event_payload = await request.get_json()
-    logging.info("Received the following webhook payload: \n%s", json.dumps(event_payload, indent=4))
+    logging.info("Received the following webhook payload: \n%s",
+                 json.dumps(event_payload, indent=4))
 
     if event_payload is None:
         return {'message': 'not a valid GitHub event'}, 400, {}
 
+    action = ""
+    if 'action' in event_payload:
+        action = event_payload.get('action')
+
     relay.events.emit({
-          'event_payload': event_payload,
-          'github_event': event_payload['action']
-      })
+        'event_payload': event_payload,
+        'github_event': action,
+    })
 
     return {'message': 'success'}, 200, {}
 


### PR DESCRIPTION
Fixes a crash in the webhook trigger if the `action` property does not exist. This includes the [push ](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#push)event, most notably.

[GitHub Webhook Events and Payloads](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#webhook-payload-object-common-properties)

`Most webhook payloads contain an action property that contains the specific activity that triggered the event.`