### PR TITLE
Add event type to emitted event

### DIFF
--- a/triggers/github-trigger-event-sink/README.md
+++ b/triggers/github-trigger-event-sink/README.md
@@ -22,6 +22,8 @@ needs to be unwrapped at the step level in order to use it; see the example belo
 
 ```yaml
 parameters:
+  github_event:
+    description: "The type of the incoming github event"
   event_payload:
     description: "The full json payload from the incoming github event"
 triggers:
@@ -31,12 +33,13 @@ triggers:
       image: relaysh/github-trigger-event-sink
     binding:
       parameters:
-        event_payload: !Data event_payload
+        github_event: ${event.github_event}
+        event_payload: ${event.event_payload}
 steps:
   - name: dump-payload
     image: relaysh/core
     spec:
-      event_payload: !Parameter event_payload
+      event_payload: ${parameters.event_payload}
     input:
       - mkdir -p /github/workflow
       - "ni get | jq .event_payload > /github/workflow/event.json"

--- a/triggers/github-trigger-event-sink/event.schema.json
+++ b/triggers/github-trigger-event-sink/event.schema.json
@@ -6,10 +6,6 @@
       "type": "string",
       "description": "Type of the Github event that triggered the webhook"
     },
-    "event_action": {
-      "type": "string",
-      "description": "The event action, if any"
-    },
     "event_payload": {
       "type": "object",
       "description": "Payload of the incoming webhook request"

--- a/triggers/github-trigger-event-sink/event.schema.json
+++ b/triggers/github-trigger-event-sink/event.schema.json
@@ -2,6 +2,14 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
+    "github_event": {
+      "type": "string",
+      "description": "Type of the Github event that triggered the webhook"
+    },
+    "event_action": {
+      "type": "string",
+      "description": "The event action, if any"
+    },
     "event_payload": {
       "type": "object",
       "description": "Payload of the incoming webhook request"

--- a/triggers/github-trigger-event-sink/handler.py
+++ b/triggers/github-trigger-event-sink/handler.py
@@ -32,9 +32,15 @@ async def handler():
     if 'action' in event_payload:
         action = event_payload.get('action')
 
+    logging.info("Emitting event_payload, event_action: \n%s\ngithub_event: \n%s",
+                 json.dumps(action, indent=4),
+                 json.dumps(github_event, indent=4)
+                 )
+
     relay.events.emit({
         'event_payload': event_payload,
-        'github_event': action,
+        'event_action': action,
+        'github_event': github_event,
     })
 
     return {'message': 'success'}, 200, {}

--- a/triggers/github-trigger-event-sink/handler.py
+++ b/triggers/github-trigger-event-sink/handler.py
@@ -28,18 +28,8 @@ async def handler():
     if event_payload is None:
         return {'message': 'not a valid GitHub event'}, 400, {}
 
-    action = ""
-    if 'action' in event_payload:
-        action = event_payload.get('action')
-
-    logging.info("Emitting event_payload, event_action: \n%s\ngithub_event: \n%s",
-                 json.dumps(action, indent=4),
-                 json.dumps(github_event, indent=4)
-                 )
-
     relay.events.emit({
         'event_payload': event_payload,
-        'event_action': action,
         'github_event': github_event,
     })
 

--- a/triggers/github-trigger-event-sink/trigger.yaml
+++ b/triggers/github-trigger-event-sink/trigger.yaml
@@ -33,4 +33,5 @@ examples:
       image: relaysh/github-trigger-event-sink
     binding:
       parameters:
-        event_payload: !Data event_payload
+        github_event: ${event.github_event}
+        event_payload: ${event.event_payload}


### PR DESCRIPTION
This PR adds the event type to the emitted event. It is not in the original payload of the event since it's passed in the header.
Without the event type present, this trigger is much less useful since the workflow needs to be able to take different steps based on the event type.