### PR TITLE
Add ability to filter for desired fields

### DIFF
--- a/steps/repositories-describe/README.md
+++ b/steps/repositories-describe/README.md
@@ -10,5 +10,5 @@ filtering and ordering the list. If you pass a name, it will return a complete
 object representing that repository. If you pass filter/order params, it will
 return a list of all matching repos.
 
-By default, this list is only the full name of each repository. If you'd like
+By default, this list is only the name of each repository. If you'd like
 more fields returned, list them in the `fields` parameter.

--- a/steps/repositories-describe/README.md
+++ b/steps/repositories-describe/README.md
@@ -2,3 +2,13 @@
 
 This step will describe the repositories belonging to an organization. It requires a
 token with the proper access, otherwise you'll very quickly hit GitHub API rate-limiting.
+
+## Usage
+
+Pass a token and the org name, and then either the name or some parameters for
+filtering and ordering the list. If you pass a name, it will return a complete
+object representing that repository. If you pass filter/order params, it will
+return a list of all matching repos.
+
+By default, this list is only the full name of each repository. If you'd like
+more fields returned, list them in the `fields` parameter.

--- a/steps/repositories-describe/spec.schema.json
+++ b/steps/repositories-describe/spec.schema.json
@@ -20,6 +20,10 @@
       "type": "string",
       "description": "The GitHub org to query."
     },
+    "name": {
+      "type": "string",
+      "description": "The name of a single repo within the org to return."
+    },
     "scope": {
       "type": "string",
       "description": "The repository scope or type to query for. (all, public, private, forks, sources, member)",
@@ -34,6 +38,13 @@
       "type": "string",
       "description": "The direction to sort by. (asc, desc)",
       "default": "asc"
+    },
+    "fields": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Additional fields to return in the output."
     }
   },
   "required": [

--- a/steps/repositories-describe/step.py
+++ b/steps/repositories-describe/step.py
@@ -45,8 +45,8 @@ try:
     repos = gh.get_organization(org).get_repos(type=scope, sort=sort, direction=direction)
     repos = list(map(lambda x: x.raw_data, repos))
 
-    # ensure that the full_name is part of the fields; doesn't matter if it's there twice
-    fields.insert(0, 'full_name')
+    # ensure that the name is part of the fields; doesn't matter if it's there twice
+    fields.insert(0, 'name')
 
     # now filter to have only the fields requested so that we don't exceed payload size when saving output.
     repos = list(map(lambda repo: { key: repo[key] for key in fields }, repos))

--- a/steps/repositories-describe/step.py
+++ b/steps/repositories-describe/step.py
@@ -11,6 +11,11 @@ except:
   raise ValueError("Token and org are required parameters")
 
 try:
+  name = relay.get(D.name)
+except:
+  name = None
+
+try:
   scope = relay.get(D.scope)
 except:
   scope = "all"
@@ -25,13 +30,28 @@ try:
 except:
   direction = "asc"
 
+try:
+  fields = relay.get(D.fields)
+except:
+  fields = []
+
 gh = Github(token)
 
 try:
-  repos = gh.get_organization(org).get_repos(type=scope, sort=sort, direction=direction)
-  repos = list(map(lambda x: x.raw_data, repos))
-except UnknownObjectException as err:
-  print(f'Unknown org {org}.')
-  raise
+  if name:
+    repo = gh.get_organization(org).get_repo(name)
+    relay.outputs.set("repository", repo.raw_data)
+  else:
+    repos = gh.get_organization(org).get_repos(type=scope, sort=sort, direction=direction)
+    repos = list(map(lambda x: x.raw_data, repos))
 
-relay.outputs.set("repositories", repos)
+    # ensure that the full_name is part of the fields; doesn't matter if it's there twice
+    fields.insert(0, 'full_name')
+
+    # now filter to have only the fields requested so that we don't exceed payload size when saving output.
+    repos = list(map(lambda repo: { key: repo[key] for key in fields }, repos))
+
+    relay.outputs.set("repositories", repos)
+except UnknownObjectException as err:
+  print(f'Unknown organization or repository.')
+  raise


### PR DESCRIPTION
The returned list of repositories is often too large of a payload. By
default, this just lists the repository names, but allows the user to
specify a list of additional fields they'd like to return.
