### PR TITLE
Add a step to validate the CODEOWNERS file

### DIFF
--- a/steps/repositories-check-codeowners/Dockerfile
+++ b/steps/repositories-check-codeowners/Dockerfile
@@ -1,0 +1,13 @@
+FROM relaysh/core:latest-python
+RUN apk add --no-cache build-base libffi-dev \
+    && pip --no-cache-dir install PyGithub   \
+    && apk --no-cache del build-base
+
+COPY "./step.py" "/step.py"
+ENTRYPOINT []
+CMD ["python3", "/step.py"]
+
+LABEL "org.opencontainers.image.title"="GitHub step check repositories for valid CODEOWNER"
+LABEL "org.opencontainers.image.description"="This step validates the CODEOWNERS file in all the repositories listed"
+LABEL "sh.relay.sdk.version"="v1"
+

--- a/steps/repositories-check-codeowners/spec.schema.json
+++ b/steps/repositories-check-codeowners/spec.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "connection": {
+      "type": "object",
+      "description": "A GitHub connection",
+      "properties": {
+        "accessToken": {
+          "type": "string",
+          "writeOnly": true,
+          "description": "A GitHub access token"
+        }
+      },
+      "required": [
+        "accessToken"
+      ]
+    },
+    "org": {
+      "type": "string",
+      "description": "The GitHub org to query."
+    },
+    "repos": {
+       "type": "array",
+       "items": {
+       "type": "string"
+       },
+       "description": "A list of repositories to validate."
+     }
+  },
+  "required": [
+    "org",
+    "repos"
+  ],
+  "additionalProperties": false
+}

--- a/steps/repositories-check-codeowners/step.py
+++ b/steps/repositories-check-codeowners/step.py
@@ -26,7 +26,7 @@ for repo in repos:
 
     with urllib.request.urlopen(req) as url:
       data = json.loads(url.read().decode())
-      if data['errors'] or data['message'] == 'Not Found':
+      if 'errors' in data.keys() or data['message'] == 'Not Found':
         failures.append(repo['name'])
 
   except Exception as err:

--- a/steps/repositories-check-codeowners/step.py
+++ b/steps/repositories-check-codeowners/step.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+import urllib.request, json
+from github import Github, UnknownObjectException, GithubException
+from relay_sdk import Interface, Dynamic as D
+
+relay = Interface()
+
+try:
+  token = relay.get(D.connection.accessToken)
+  org   = relay.get(D.org)
+  repos = relay.get(D.repos)
+except:
+  raise ValueError("Token, org, and repos are required parameters")
+
+gh = Github(token)
+
+failures = []
+for repo in repos:
+  try:
+    print(f'Checking CODEOWNERS for {repo["name"]}... ', end='')
+
+    # Do it manually until https://github.com/PyGithub/PyGithub/pull/2275 is released
+    req = urllib.request.Request(f'https://api.github.com/repos/{org}/{repo["name"]}/codeowners/errors')
+    req.add_header('User-agent', 'Relay.sh')
+    req.add_header('Authorization', f'token {token}')
+
+    with urllib.request.urlopen(req) as url:
+      data = json.loads(url.read().decode())
+      if data['errors'] or data['message'] == 'Not Found':
+        failures.append(repo['name'])
+
+  except Exception as err:
+    print(f'Problem with repo: {err}.')
+
+relay.outputs.set("failures", failures)

--- a/steps/repositories-check-codeowners/step.yaml
+++ b/steps/repositories-check-codeowners/step.yaml
@@ -1,0 +1,62 @@
+# The schema version. Required. Must be exactly the string "integration/v1".
+apiVersion: integration/v1
+
+# The schema kind. Required. Must be one of "Query", "Step", or "Trigger"
+# corresponding to its directory location.
+kind: Step
+
+# The name of the action. Required. Must be exactly the name of the directory
+# containing the action.
+name: repositories-check-codeowners
+
+# The version of the action. Required. Must be an integer. If specified in the
+# directory name, must be exactly the version in the directory name.
+version: 1
+
+# High-level phrase describing what this action does. Required.
+summary: Validate that all listed repositories have valid CODEOWNERS files
+
+# Single-paragraph explanation of what this action does in more detail.
+# Optional. Markdown.
+description: |
+  This uses the GitHub API to quickly validate CODEOWNERS files. It does not do
+  any advanced checks; for that you might try https://github.com/mszostok/codeowners-validator
+# URL or path relative to this file to an icon or icons representing this
+# action. Optional. Defaults to the integration icon.
+icon:
+
+# The mechanism to use to construct this step. Required. Must be an action
+# builder. See the Builders section below.
+build:
+  # The schema version for builders. Required. For now, must be the exact
+  # string "build/v1". We may consider supporting custom third-party builders
+  # in the future.
+  apiVersion: build/v1
+
+  # The builder to use. Required.
+  kind: Docker
+
+publish:
+  repository: relaysh/github-step-repositories-check-codeowners
+
+schemas:
+  spec:
+    source: file
+    file: spec.schema.json
+  outputs:
+    source: file
+    file: outputs.schema.json
+
+examples:
+- summary: Check that the CODEOWNERS file is valid
+  content:
+    apiVersion: v1
+    kind: Step
+    name: check-codeowners
+    image: relaysh/github-step-repositories-check-codeowners
+    spec:
+      github:
+        connection:
+          accessToken: ${secrets.my-github-access-token}
+        org: !Parameter my-org
+        repos: !Parameter ['list', 'of', 'repo', 'names']


### PR DESCRIPTION
This uses the new codewoner errors API to quickly validate the
CODEOWNERS file. If you want something more complex, you should use
something like https://github.com/mszostok/codeowners-validator
